### PR TITLE
Pin AWS CDK dependencies at 1.65.0

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -36,10 +36,10 @@
     "deploy-lambda": "npm run build && cdk deploy PowerTunerLambdaStack"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.63.0",
+    "@aws-cdk/assert": "1.65.0",
     "@types/jest": "^25.2.3",
     "@types/node": "10.17.5",
-    "aws-cdk": "1.63.0",
+    "aws-cdk": "1.65.0",
     "jest": "^25.5.4",
     "ts-jest": "^25.3.1",
     "ts-node": "^8.1.0",
@@ -47,11 +47,11 @@
     "node-forge": ">=0.10.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "1.63.0",
-    "@aws-cdk/aws-iam": "1.63.0",
-    "@aws-cdk/aws-lambda": "^1.55.0",
-    "@aws-cdk/aws-sam": "^1.55.0",
-    "@aws-cdk/core": "1.63.0",
+    "@aws-cdk/aws-apigateway": "1.65.0",
+    "@aws-cdk/aws-iam": "1.65.0",
+    "@aws-cdk/aws-lambda": "1.65.0",
+    "@aws-cdk/aws-sam": "1.65.0",
+    "@aws-cdk/core": "1.65.0",
     "cdk-lambda-powertuner": "0.2.2",
     "cdk-spa-deploy": "1.54.0",
     "source-map-support": "^0.5.16"


### PR DESCRIPTION
When trying to set the AWS Power Tuner UI up without the updated / pinned CDK versions, the `deploy-infra` operation fails with: 

> unable to determine cloud assembly output directory. Assets must be defined indirectly within a "Stage" or an "App" scope

From looking into the issue, I discovered that this is typically due to mismatched versions on CDK dependencies.