### PR TITLE
update to version 3.4.1 and extend UI options to 10 GB

### DIFF
--- a/cdk/lib/power-tuner-stack.ts
+++ b/cdk/lib/power-tuner-stack.ts
@@ -23,7 +23,7 @@ export class PowerTunerStack extends cdk.Stack {
     const powerTuner = new sam.CfnApplication(this as any, 'powerTuner', {
       location: {
         applicationId: 'arn:aws:serverlessrepo:us-east-1:451282441545:applications/aws-lambda-power-tuning',
-        semanticVersion: '3.2.4'
+        semanticVersion: '3.4.1'
       },
       parameters: {
         'lambdaResource': `arn:aws:lambda:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:function:*`,

--- a/website/src/app/app.component.ts
+++ b/website/src/app/app.component.ts
@@ -131,7 +131,7 @@ export class AppComponent implements OnInit {
   getPowerValues() {
     const increment = 64;
     const powerValues = [];
-    for (let value = 128; value <= 3008; value += increment) {
+    for (let value = 128; value <= 10240; value += increment) {
       powerValues.push(value);
     }
     return powerValues;


### PR DESCRIPTION
Closes Issue #5 
update to version 3.4.1 of lambda power tuner, extend the options to 10GB memory in UI